### PR TITLE
base: wait-for-it.sh added to container

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,8 +1,12 @@
-from ubuntu
+from ubuntu:20.04
 
 RUN apt-get update && \
     apt-get install -y \
     bash curl net-tools \
     dnsutils iputils-ping
+
+RUN curl -o /usr/local/bin/wait-for-it.sh \
+    https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
+    && chmod 755 /usr/local/bin/wait-for-it.sh
 
 ENTRYPOINT [ "bash" ]

--- a/base/README.md
+++ b/base/README.md
@@ -1,5 +1,11 @@
 ### build base container
 
 ```
-docker build -t base .
+docker build -t micarlise/container-tools:base .
+```
+
+### push to docker hub
+
+```
+docker push micarlise/container-tools:base
 ```


### PR DESCRIPTION
pulls from an external repo until we figure out what we want to do.